### PR TITLE
Added Docker support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM alpine:latest AS mqttsm-build
+
+RUN echo 'https://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories; \
+	echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories;
+
+RUN	apk update; \
+	apk add --no-cache \
+	git \
+	meson \
+	ninja \
+	build-base \
+	cmake \
+	openssl-dev \
+	paho-mqtt-c-dev \
+	readline-dev \
+	lua-dev 
+		
+RUN	git clone https://github.com/cmargiotta/MQTT-System-Monitor --recurse
+
+RUN cd MQTT-System-Monitor; \
+	meson build; \
+	ninja -C build test
+
+FROM alpine:latest
+
+RUN echo 'https://dl-cdn.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories; \
+	echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories;
+
+RUN	apk update; \
+	apk add --no-cache \
+	libstdc++ \
+	paho-mqtt-c-dev \
+	lua-dev 
+		
+COPY --from=mqttsm-build /MQTT-System-Monitor/build/src/msm /usr/bin/
+
+VOLUME [ "/etc/msm"]
+WORKDIR /etc/msm
+ENTRYPOINT ["/usr/bin/msm"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t mqttsm .
+
+start:
+	docker run -d -v $PWD/../config:/etc/msm:ro -name mqtt-system-monitor mqttsm


### PR DESCRIPTION
Added the ability to install your application in the Docker container. This will simplify the installation and build.

The assembly is carried out in split containers. One for build (400MB), the second with the end application (28MB).

I spent a lot of time searching for all dependencies. For example, `paho.mqtt.cpp` requires `paho.mqtt.c`, which should be installed in the system, but it is absent in most distributions. I would even propose to carry out static assembly `paho.mqtt.c` using `meson`. I don’t understand why you are collecting `paho.mqtt.cpp` with `Opensl`, if SSL is not used in the application.

P.S. If you still decide to finalize the application, mention me on Github. I will finalize `Dockerfile`
